### PR TITLE
Privacy: do not send referrer header to Pushshift

### DIFF
--- a/src/api.tsx
+++ b/src/api.tsx
@@ -50,7 +50,9 @@ export class PushshiftAPI {
     }
     let url = `https://api.pushshift.io/reddit/${endpoint}/search?${joinedArgs}`;
     console.log(`Pushshift request ${url}`);
-    let resp = await fetch(url);
+    let resp = await fetch(url, {
+       referrerPolicy = "no-referrer"
+    });
     let data = await resp.json();
     return [data, url];
   }


### PR DESCRIPTION
Pushshift reads and uses the referrer header to change whether access is granted to the site. This change strips the referrer field from the request sent to Pushshift.