### PR TITLE
Remove "pushshift is blocking API requests" message on errors

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -393,7 +393,6 @@ export class App extends React.Component<{}, AppState> {
           {this.state.error &&
             <>
               <p className="text-red-200 text-center">{this.state.errorTime.toLocaleTimeString()} Error: {this.state.error}</p>
-              <p className="text-red-200 text-center"><a href="https://www.reddit.com/r/pushshift/comments/gtkytk/the_pushshift_api_will_be_blocking_any_requests/">See: https://www.reddit.com/r/pushshift/comments/gtkytk/the_pushshift_api_will_be_blocking_any_requests/</a></p>
             </>
           }
         </form>


### PR DESCRIPTION
A while back pushshift was blocking API requests. This hasn't been the case for a while now, however this message still shows up whenever there's an error from pushshift.

Devs will need to make sure to update the `gh-pages` branch accordingly. It uses a completely different codebase which is mostly contained in one huge file that github can't display (and I don't feel like downloading and configuring and pushing the whole repo).